### PR TITLE
findLimeSDR.py example leaves board undiscoverable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+*.egg

--- a/pyLMS7002M/LimeSDR.py
+++ b/pyLMS7002M/LimeSDR.py
@@ -131,6 +131,8 @@ class LimeSDR(object):
         """
         if self.usbBackend=="LimeAPI":
             del self.cyDev
+        else:
+            self.usb.closeDevice()
     
     @staticmethod
     def findLMS7002(backend="PyUSB"):

--- a/pyLMS7002M/LimeSDR.py
+++ b/pyLMS7002M/LimeSDR.py
@@ -15,6 +15,7 @@ from Si5351 import *
 from boardUSB import *
 from LimeSDR_FPGA import *
 from timeit import default_timer as timer
+import atexit
 
 # Try to import the LimeAPI library
 try:
@@ -62,6 +63,11 @@ class LimeSDR(object):
                 raise ValueError("LimeSDR not found")            
             self.usb = self.cyDev
             
+        # http://stackoverflow.com/questions/8907905/del-myclass-doesnt-call-object-del
+        # https://docs.python.org/3/reference/datamodel.html#object.__del__
+        # solution is to avoid __del__, define an explict close() and call it atexit
+        atexit.register(self.close)
+
         #self.usb.setConfiguration()
         self.verbose = verbose
         self.bulkControl = False
@@ -125,7 +131,7 @@ class LimeSDR(object):
         self.ADF4002 = ADF4002(Proxy(self.ADF4002Program))
         self.FPGA = LimeSDR_FPGA(spiRead=Proxy(self.BoardSPI_Read), spiWrite=Proxy(self.BoardSPI_Write), usb=self.usb)
         
-    def __del__(self):
+    def close(self):
         """
         Close communication with LimeSDR
         """

--- a/pyLMS7002M/boardUSB.py
+++ b/pyLMS7002M/boardUSB.py
@@ -81,5 +81,7 @@ class boardUSB(object):
         """
         Close USB device
         """
-        self.dev.reset()
+        # https://www.mail-archive.com/pyusb-users@lists.sourceforge.net/msg00624.html
+        usb.util.dispose_resources(self.dev)
+        self.dev = None
         

--- a/pyLMS7002M/boardUSB.py
+++ b/pyLMS7002M/boardUSB.py
@@ -77,4 +77,9 @@ class boardUSB(object):
         """
         return self.dev.read(endpoint, nBytes, timeout)
         
-    
+    def closeDevice(self):
+        """
+        Close USB device
+        """
+        self.dev.reset()
+        


### PR DESCRIPTION
Hi,

I believe the solution to the [problem](https://github.com/myriadrf/pyLMS7002M/issues/1) for macos is two fold:
  1. ensure the cleanup routine in class LimeSDR is called.  I observed that the ```__del__()``` was not being called (see references in the code).  The ```atexit``` method with an explicit ```close()``` seems best for this implementation
  1. call ```pyusb``` function util.dispose_resources() in the ```boardUSB``` function ```closeDevice()```

With these changes, I am able to run the programs more than once without error:
```
(pyLMS7002m) $ python -c "from pyLMS7002M import * ; limeSDR = LimeSDR()"
(pyLMS7002m) $ python -c "from pyLMS7002M import * ; limeSDR = LimeSDR()"
(pyLMS7002m) $ python -c "from pyLMS7002M import * ; limeSDR = LimeSDR()"
(pyLMS7002m) $ python examples/basic/findLimeSDR.py 
Searching for LimeSDR...

LimeSDR info:
FW_VER           : 3
DEV_TYPE         : 14
LMS_PROTOCOL_VER : 1
HW_VER           : 4
EXP_BOARD        : 1

LMS7002M info:
VER              : 7
REV              : 1
MASK             : 1
(pyLMS7002m) $ python examples/basic/findLimeSDR.py 
Searching for LimeSDR...

LimeSDR info:
FW_VER           : 3
DEV_TYPE         : 14
LMS_PROTOCOL_VER : 1
HW_VER           : 4
EXP_BOARD        : 1

LMS7002M info:
VER              : 7
REV              : 1
MASK             : 1
(pyLMS7002m) $ python examples/basic/findLimeSDR.py 
Searching for LimeSDR...

LimeSDR info:
FW_VER           : 3
DEV_TYPE         : 14
LMS_PROTOCOL_VER : 1
HW_VER           : 4
EXP_BOARD        : 1

LMS7002M info:
VER              : 7
REV              : 1
MASK             : 1
```